### PR TITLE
VerifyToken cannot validate expectedPublicKey, only sig

### DIFF
--- a/src/peer-discovery-services/SHIP/SHIPTopicManager.ts
+++ b/src/peer-discovery-services/SHIP/SHIPTopicManager.ts
@@ -44,7 +44,7 @@ export class SHIPTopicManager implements TopicManager {
           // if (!isValidTopicName(topic)) continue
 
           // Verify the token locking key and signature
-          verifyToken(identityKey, result.lockingPublicKey, result.fields, result.signature, 'SHIP')
+          verifyToken(identityKey, result.lockingPublicKey, result.fields, result.signature)
 
           outputsToAdmit.push(i)
         } catch (error) {

--- a/src/peer-discovery-services/SLAP/SLAPTopicManager.ts
+++ b/src/peer-discovery-services/SLAP/SLAPTopicManager.ts
@@ -44,7 +44,7 @@ export class SLAPTopicManager implements TopicManager {
           if (!isValidServiceName(service)) continue
 
           // Verify the token locking key and signature
-          verifyToken(identityKey, result.lockingPublicKey, result.fields, result.signature, 'SLAP')
+          verifyToken(identityKey, result.lockingPublicKey, result.fields, result.signature)
 
           outputsToAdmit.push(i)
         } catch (error) {

--- a/src/peer-discovery-services/utils/verifyToken.ts
+++ b/src/peer-discovery-services/utils/verifyToken.ts
@@ -1,5 +1,4 @@
 import { PublicKey, Signature } from '@bsv/sdk'
-import { getPaymentAddress } from 'sendover'
 import dotenv from 'dotenv'
 dotenv.config()
 
@@ -16,20 +15,8 @@ export const verifyToken = (
   identityKey: string,
   lockingPublicKey: string,
   fields: Buffer[],
-  signature: string,
-  protocolId: string
+  signature: string
 ): void => {
-  const expectedPublicKey = getPaymentAddress({
-    senderPrivateKey: process.env.SERVER_PRIVATE_KEY,
-    recipientPublicKey: identityKey,
-    invoiceNumber: `2-${protocolId}-1`, // BRC-43 formatted invoice number
-    returnType: 'publicKey'
-  })
-
-  if (expectedPublicKey !== lockingPublicKey) {
-    throw new Error('Invalid locking key!')
-  }
-
   const pubKey = PublicKey.fromString(lockingPublicKey)
   const hasValidSignature = pubKey.verify(
     Array.from(Buffer.concat(fields)),


### PR DESCRIPTION
If an incoming SHIP/SLAP token is from an external party, the expectedPublicKey cannot be computed because we don't know their private key. 

Signature verification is sufficient in this case.