### PR TITLE
Arc ingest must respond

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -276,7 +276,7 @@ app.post('/arc-ingest', (req, res) => {
       console.log('merklePath', req.body.merklePath)
       const merklePath = MerklePath.fromHex(req.body.merklePath)
       await engine.handleNewMerkleProof(req.body.txid, merklePath)
-      return res.status(200)
+      return res.status(200).json({ status: 'success', message: 'transaction status updated' })
     } catch (error) {
       console.error(error)
       return res.status(400).json({


### PR DESCRIPTION
Otherwise we timeout and ARC will attempt to resend status update with expo backoff.