### PR TITLE
Resolve circular dependency issue with NinjaAdvertiser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ const SYNC_CONFIGURATION: SyncConfiguration = {
 
 // Initialization the overlay engine
 let engine: Engine
-let ninjaAdvertiser: Advertiser
+let ninjaAdvertiser: NinjaAdvertiser
 const initialization = async () => {
   console.log('Starting initialization...')
   try {
@@ -110,6 +110,7 @@ const initialization = async () => {
         ninjaAdvertiser,
         SYNC_CONFIGURATION
       )
+      ninjaAdvertiser.setLookupEngine(engine)
       console.log('Engine initialized successfully')
     } catch (engineError) {
       console.error('Error during Engine initialization:', engineError)
@@ -276,7 +277,7 @@ app.post('/arc-ingest', (req, res) => {
       console.log('merklePath', req.body.merklePath)
       const merklePath = MerklePath.fromHex(req.body.merklePath)
       await engine.handleNewMerkleProof(req.body.txid, merklePath)
-      return res.status(200)
+      return res.status(200).json({ status: 'success', message: 'transaction status updated' })
     } catch (error) {
       console.error(error)
       return res.status(400).json({

--- a/src/peer-discovery-services/NinjaAdvertiser.ts
+++ b/src/peer-discovery-services/NinjaAdvertiser.ts
@@ -13,8 +13,8 @@ const AD_TOKEN_VALUE = 1
  * Implements the Advertiser interface for managing SHIP and SLAP advertisements using a Ninja.
  */
 export class NinjaAdvertiser implements Advertiser {
-  ninja: Ninja
-  engine: Engine | undefined
+  private readonly ninja: Ninja
+  private engine: Engine | undefined
 
   /**
    * Constructs a new NinjaAdvertiser instance.


### PR DESCRIPTION
Supports injection of the Engine dependency into the NinjaAdvertiser after initialization.
This is required only by this specific implementation of the Advertiser which uses the Engine's lookup function for querying advertisements.